### PR TITLE
Replace ember-cli/lib/ext/promise with rsvp

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@
 'use strict';
 
 var nodemon = require('nodemon');
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 var path = require('path');
 var which = require('which');
+
+var { Promised } = RSVP;
 
 module.exports = {
   name: 'ember-autoserve',


### PR DESCRIPTION
Hopefully, this will remove this deprecation warning:

```
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead. Required here:
  Object.<anonymous> (/node_modules/ember-autoserve/index.js:5:15)
```